### PR TITLE
Switch to the Commonhaus Develocity instance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
           -Pjqassistant -Pdist -Pci-build -DskipITs
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_BASE_URL: "${{ env.DEVELOCITY_BASE_URL || 'https://develocity.commonhaus.dev' }}"
       - name: Running integration tests in the default environment
         run: |
           ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} clean verify \
@@ -70,3 +71,4 @@ jobs:
           ${{ github.event.pull_request.base.ref && format('-Dincremental -Dgib.referenceBranch=refs/remotes/origin/{0}', github.event.pull_request.base.ref) || '' }}
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          DEVELOCITY_BASE_URL: "${{ env.DEVELOCITY_BASE_URL || 'https://develocity.commonhaus.dev' }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,11 +62,11 @@ jobs:
           ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} clean install \
           -Pjqassistant -Pdist -Pci-build -DskipITs
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Running integration tests in the default environment
         run: |
           ./mvnw $MAVEN_ARGS ${{ matrix.os.maven.args }} clean verify \
           -Pskip-checks \
           ${{ github.event.pull_request.base.ref && format('-Dincremental -Dgib.referenceBranch=refs/remotes/origin/{0}', github.event.pull_request.base.ref) || '' }}
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ nb-configuration.xml
 # Local environment
 .env
 
+# Gradle Enterprise (obsolete)
+/.mvn/.gradle-enterprise
+
 # Develocity
 /.mvn/.develocity

--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ nb-configuration.xml
 # Local environment
 .env
 
-# Gradle Enterprise/Develocity
-/.mvn/.gradle-enterprise
+# Develocity
+/.mvn/.develocity

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,6 +1,6 @@
-<gradleEnterprise
-        xmlns="https://www.gradle.com/gradle-enterprise-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://www.gradle.com/gradle-enterprise-maven https://www.gradle.com/schema/gradle-enterprise-maven.xsd">
+<develocity
+        xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
         <url>https://ge.hibernate.org</url>
         <allowUntrusted>false</allowUntrusted>
@@ -16,12 +16,17 @@
         <!--
         Expression support is documented here: https://docs.gradle.com/enterprise/maven-extension/#expression_support
         -->
+        <publishing>
+            <onlyIf>
+                <![CDATA[authenticated]]>
+            </onlyIf>
+        </publishing>
         <obfuscation>
-          <!-- Don't share ip addresses-->
-          <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+            <!-- Don't share ip addresses-->
+            <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
         </obfuscation>
         <capture>
-          <goalInputFiles>true</goalInputFiles>
+            <fileFingerprints>true</fileFingerprints>
         </capture>
         <!-- https://docs.gradle.com/enterprise/maven-extension/#manual_access_key_configuration -->
         <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
@@ -38,4 +43,4 @@
             </server>
         </remote>
     </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -2,7 +2,7 @@
         xmlns="https://www.gradle.com/develocity-maven" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.gradle.com/develocity-maven https://www.gradle.com/schema/develocity-maven.xsd">
     <server>
-        <url>https://ge.hibernate.org</url>
+        <url>#{env['DEVELOCITY_BASE_URL']?:'https://develocity.commonhaus.dev'}</url>
         <allowUntrusted>false</allowUntrusted>
     </server>
     <buildScan>
@@ -38,9 +38,6 @@
         <remote>
             <enabled>#{properties['no-build-cache'] == null}</enabled>
             <storeEnabled>#{env['CI'] != null and (env['CHANGE_ID']?:'').isBlank() and (env['GITHUB_BASE_REF']?:'').isBlank() and !(env['GRADLE_ENTERPRISE_ACCESS_KEY']?:'').isBlank()}</storeEnabled>
-            <server>
-                <url>https://ge.hibernate.org/cache/hsearchtest01/</url>
-            </server>
         </remote>
     </buildCache>
 </develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,12 +1,12 @@
 <extensions>
     <extension>
         <groupId>com.gradle</groupId>
-        <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.20.1</version>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.23.2</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>1.13</version>
+        <version>2.0.1</version>
     </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def withMavenWorkspace(Closure body) {
 					junitPublisher(disabled: true)
 			]) {
 		withCredentials([string(credentialsId: 'ge.hibernate.org-access-key',
-				variable: 'GRADLE_ENTERPRISE_ACCESS_KEY')]) {
+				variable: 'DEVELOCITY_ACCESS_KEY')]) {
 			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 				body()
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,16 +7,12 @@ def withMavenWorkspace(Closure body) {
 					artifactsPublisher(disabled: true),
 					junitPublisher(disabled: true)
 			]) {
-		def develocityMainCredentialsId = helper.configuration.file?.develocity?.credentials?.main
-		def develocityBaseUrl = helper.configuration.file?.develocity?.url
-		withEnv(["DEVELOCITY_BASE_URL=${develocityBaseUrl}"]) {
-            withCredentials([string(credentialsId: develocityMainCredentialsId,
-                    variable: 'DEVELOCITY_ACCESS_KEY')]) {
-                withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-                    body()
-                }
-            }
-        }
+		// These credentials can only push reports.
+		withCredentials([string(credentialsId: 'ge.hibernate.org-access-key-pr')]) {
+			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
+				body()
+			}
+		}
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,12 +7,16 @@ def withMavenWorkspace(Closure body) {
 					artifactsPublisher(disabled: true),
 					junitPublisher(disabled: true)
 			]) {
-		withCredentials([string(credentialsId: 'ge.hibernate.org-access-key',
-				variable: 'DEVELOCITY_ACCESS_KEY')]) {
-			withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
-				body()
-			}
-		}
+		def develocityMainCredentialsId = helper.configuration.file?.develocity?.credentials?.main
+		def develocityBaseUrl = helper.configuration.file?.develocity?.url
+		withEnv(["DEVELOCITY_BASE_URL=${develocityBaseUrl}"]) {
+            withCredentials([string(credentialsId: develocityMainCredentialsId,
+                    variable: 'DEVELOCITY_ACCESS_KEY')]) {
+                withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
+                    body()
+                }
+            }
+        }
 	}
 }
 


### PR DESCRIPTION
- Switch to the Commonhaus Develocity instance
  - Hibernate Develocity URLs point to the Commonhaus instance
  - Develocity credential id in Jenkinsfile is pulled from helper
- Migrate from Gradle Enterprise extension to the latest Develocity extension
  - Related build configuration is updated
  - GHA workflows and Jenkins jobs use `DEVELOCITY_ACCESS_KEY` environment variable and secret
- Update Common Custom User Data Maven extension to latest version